### PR TITLE
Fixed `video2frame.py` error in unix

### DIFF
--- a/loader/video2frame.py
+++ b/loader/video2frame.py
@@ -53,7 +53,7 @@ def main():
     parser.add_argument(
         'output_dir',
         nargs='?',
-        default='./extracted',
+        default='extracted',
         help='output directory',
     )
     parser.add_argument(

--- a/loader/video2frame.py
+++ b/loader/video2frame.py
@@ -28,7 +28,7 @@ def process_videos(
             output_dir,
             align_info=align_result,
             fps=fps,
-            resolution=resolution
+            resolution=resolution,
         )
 
     return outputs
@@ -53,8 +53,14 @@ def main():
     parser.add_argument(
         'output_dir',
         nargs='?',
-        default='extracted',
+        default='./extracted',
         help='output directory',
+    )
+    parser.add_argument(
+        '--fps',
+        help='target_fps',
+        type=int,
+        default=10,
     )
     parser.add_argument(
         '--working_dir',
@@ -79,7 +85,7 @@ def main():
         target_files,
         args.output_dir,
         args.working_dir,
-        fps=10,
+        fps=args.fps,
         resolution=(960, 540)
     )
 

--- a/sync/ffmpeg.py
+++ b/sync/ffmpeg.py
@@ -34,7 +34,7 @@ def _build_filename(
         features.append(f'{resolution[0]}x{resolution[1]}')
 
     if features:
-        ret = f'{base_wo_ext}_({"_".join(features)})'
+        ret = f'{base_wo_ext}_{"_".join(features)}'
     else:
         ret = f'{base_wo_ext}'
     return ret, extension

--- a/sync/ffmpeg.py
+++ b/sync/ffmpeg.py
@@ -110,9 +110,9 @@ def encode_video_single(
     _logger.info(f'encode {video} to {output_file}')
     # _logger.debug(f'cmd {cmd_str}')
     if silent:
-        subprocess.check_call(cmd_str, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+        subprocess.check_call(cmd_str, shell=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
     else:
-        subprocess.check_call(cmd_str)
+        subprocess.check_call(cmd_str, shell=True)
     return output_path
 
 

--- a/sync/ffmpeg.py
+++ b/sync/ffmpeg.py
@@ -34,7 +34,7 @@ def _build_filename(
         features.append(f'{resolution[0]}x{resolution[1]}')
 
     if features:
-        ret = f'{base_wo_ext}_({"_".join(features)'
+        ret = f'{base_wo_ext}_({"_".join(features)})'
     else:
         ret = f'{base_wo_ext}'
     return ret, extension

--- a/sync/ffmpeg.py
+++ b/sync/ffmpeg.py
@@ -2,7 +2,6 @@
 import os
 import logging
 import subprocess
-import shutil
 
 from typing import Optional, Tuple, Dict, Any, List, Union
 
@@ -103,13 +102,15 @@ def encode_video_single(
         os.makedirs(output_path, exist_ok=True)
     else:
         output_file = output_path
+        os.makedirs(output_dir, exist_ok=True)
+
     cmd.append(output_file)
 
     cmd_str = ' '.join(cmd)
     _logger.info(f'encode {video} to {output_file}')
     # _logger.debug(f'cmd {cmd_str}')
     if silent:
-        subprocess.check_call(cmd_str, stderr=subprocess.DEVNULL)
+        subprocess.check_call(cmd_str, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
     else:
         subprocess.check_call(cmd_str)
     return output_path

--- a/sync/ffmpeg.py
+++ b/sync/ffmpeg.py
@@ -34,7 +34,7 @@ def _build_filename(
         features.append(f'{resolution[0]}x{resolution[1]}')
 
     if features:
-        ret = f'{base_wo_ext}_[{"_".join(features)}]'
+        ret = f'{base_wo_ext}_({"_".join(features)'
     else:
         ret = f'{base_wo_ext}'
     return ret, extension


### PR DESCRIPTION
jungsup님이 알려주신 이슈를 해결했습니다.
- 맥/리눅스에서 file path, file name 정책이 달라 정상적으로 파일을 읽고 쓸 수 없는 문제 
  - 캐싱용 이름 수정
  - default path에 `./`(현재디렉토리) 추가
- subprocess 모듈에서 command 실행이 정상적으로 되지 않던 문제